### PR TITLE
Add use stmt for Builder param

### DIFF
--- a/src/GraphQL/Traits/FilterableQueryTrait.php
+++ b/src/GraphQL/Traits/FilterableQueryTrait.php
@@ -5,6 +5,7 @@ namespace Audentio\LaravelGraphQL\GraphQL\Traits;
 use Audentio\LaravelBase\Utils\StrUtil;
 use Audentio\LaravelGraphQL\GraphQL\Definitions\Type;
 use GraphQL\Type\Definition\InputObjectType;
+use Illuminate\Database\Eloquent\Builder;
 
 trait FilterableQueryTrait
 {


### PR DESCRIPTION
The `builder` param in `applyFilters` is of type `Illuminate\Database\Eloquent\Builder`, but it wasn't being used. Nothing big, just creates a warning in PHPStorm.